### PR TITLE
Added standard console runner output

### DIFF
--- a/ParallelMSpecRunner/Options.cs
+++ b/ParallelMSpecRunner/Options.cs
@@ -25,6 +25,7 @@ namespace ParallelMSpecRunner
             HtmlPath = string.Empty;
             XmlPath = string.Empty;
             Threads = 2;
+            StandardOutput = false;
         }
 
 
@@ -67,6 +68,10 @@ namespace ParallelMSpecRunner
         [Option("teamcity",
           HelpText = "Reporting for TeamCity CI integration (also auto-detected)")]
         public bool TeamCityIntegration { get; set; }
+
+        [Option("standardoutput",
+          HelpText = "Standard MSpec Console runner output")]
+        public bool StandardOutput { get; set; }
 
         [Option("no-teamcity-autodetect",
           HelpText = "Disables TeamCity autodetection")]

--- a/ParallelMSpecRunner/Outputs/FailedSpecificationsSummary.cs
+++ b/ParallelMSpecRunner/Outputs/FailedSpecificationsSummary.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Machine.Specifications.Runner.Utility;
+using ParallelMSpecRunner.Reporting;
+
+namespace ParallelMSpecRunner.Outputs
+{
+    class FailedSpecificationsSummary
+    {
+        readonly IBufferedConsole _console;
+
+        readonly Dictionary<ContextInfo, IList<FailedSpecification>> _failures =
+          new Dictionary<ContextInfo, IList<FailedSpecification>>();
+
+        readonly VerboseOutput _verbose;
+
+        public FailedSpecificationsSummary(VerboseOutput verbose, IBufferedConsole console)
+        {
+            _verbose = verbose;
+            _console = console;
+        }
+
+        public void WriteSummary()
+        {
+            if (!_failures.Any())
+            {
+                return;
+            }
+
+            _console.WriteLine("");
+            _console.WriteLine("Failures:");
+
+            _failures
+              .OrderBy(context => context.Key.FullName)
+              .ToList()
+              .ForEach(context =>
+              {
+                  _verbose.ContextStart(context.Key);
+                  context.Value.ToList().ForEach(spec =>
+                  {
+                      _verbose.SpecificationStart(spec.Specification);
+                      _verbose.Failed(spec.Specification, spec.Result);
+                  });
+              });
+        }
+
+        public void RecordFailure(ContextInfo context, SpecificationInfo specification, Result result)
+        {
+            if (!_failures.ContainsKey(context))
+            {
+                _failures.Add(context, new List<FailedSpecification>());
+            }
+
+            var entry = _failures[context];
+            entry.Add(new FailedSpecification { Specification = specification, Result = result });
+        }
+    }
+}

--- a/ParallelMSpecRunner/Outputs/IOutput.cs
+++ b/ParallelMSpecRunner/Outputs/IOutput.cs
@@ -1,0 +1,19 @@
+﻿using Machine.Specifications.Runner.Utility;
+
+namespace ParallelMSpecRunner.Outputs
+{
+	public interface IOutput
+	{
+		void RunStart();
+		void RunEnd();
+		void AssemblyStart(AssemblyInfo assembly);
+		void AssemblyEnd(AssemblyInfo assembly);
+		void ContextStart(ContextInfo context);
+		void ContextEnd(ContextInfo context);
+		void SpecificationStart(SpecificationInfo specification);
+		void Passing(SpecificationInfo specification);
+		void NotImplemented(SpecificationInfo specification);
+		void Ignored(SpecificationInfo specification);
+		void Failed(SpecificationInfo specification, Result result);
+	}
+}

--- a/ParallelMSpecRunner/Outputs/SilentOutput.cs
+++ b/ParallelMSpecRunner/Outputs/SilentOutput.cs
@@ -1,0 +1,51 @@
+using Machine.Specifications.Runner.Utility;
+
+namespace ParallelMSpecRunner.Outputs
+{
+    public class SilentOutput : IOutput
+    {
+        public void RunStart()
+        {
+        }
+
+        public void RunEnd()
+        {
+        }
+
+        public void AssemblyStart(AssemblyInfo assembly)
+        {
+        }
+
+        public void AssemblyEnd(AssemblyInfo assembly)
+        {
+        }
+
+        public void ContextStart(ContextInfo context)
+        {
+        }
+
+        public void ContextEnd(ContextInfo context)
+        {
+        }
+
+        public void SpecificationStart(SpecificationInfo specification)
+        {
+        }
+
+        public void Passing(SpecificationInfo specification)
+        {
+        }
+
+        public void NotImplemented(SpecificationInfo specification)
+        {
+        }
+
+        public void Ignored(SpecificationInfo specification)
+        {
+        }
+
+        public void Failed(SpecificationInfo specification, Result result)
+        {
+        }
+    }
+}

--- a/ParallelMSpecRunner/Outputs/VerboseOutput.cs
+++ b/ParallelMSpecRunner/Outputs/VerboseOutput.cs
@@ -1,0 +1,81 @@
+using Machine.Specifications.Runner.Utility;
+using ParallelMSpecRunner.Reporting;
+
+namespace ParallelMSpecRunner.Outputs
+{
+    struct FailedSpecification
+    {
+        public Result Result;
+        public SpecificationInfo Specification;
+    }
+
+    class VerboseOutput : IOutput
+    {
+        readonly IBufferedConsole _console;
+
+        public VerboseOutput(IBufferedConsole console)
+        {
+            _console = console;
+        }
+
+        public void RunStart()
+        {
+        }
+
+        public void RunEnd()
+        {
+            EmptyLine();
+        }
+
+        public void AssemblyStart(AssemblyInfo assembly)
+        {
+            EmptyLine();
+            _console.WriteLine("Specs in " + assembly.Name + ":");
+        }
+
+        public void AssemblyEnd(AssemblyInfo assembly)
+        {
+        }
+
+        public void ContextStart(ContextInfo context)
+        {
+            EmptyLine();
+            _console.WriteLine(context.FullName);
+        }
+
+        public void ContextEnd(ContextInfo context)
+        {
+        }
+
+        public void SpecificationStart(SpecificationInfo specification)
+        {
+            _console.Write("» " + specification.Name);
+        }
+
+        public void Passing(SpecificationInfo specification)
+        {
+            EmptyLine();
+        }
+
+        public void NotImplemented(SpecificationInfo specification)
+        {
+            _console.WriteLine(" (NOT IMPLEMENTED)");
+        }
+
+        public void Ignored(SpecificationInfo specification)
+        {
+            _console.WriteLine(" (IGNORED)");
+        }
+
+        public void Failed(SpecificationInfo specification, Result result)
+        {
+            _console.WriteLine(" (FAIL)");
+            _console.WriteLine(result.Exception.ToString());
+        }
+
+        void EmptyLine()
+        {
+            _console.WriteLine("");
+        }
+    }
+}

--- a/ParallelMSpecRunner/ParallelMSpecRunner.csproj
+++ b/ParallelMSpecRunner/ParallelMSpecRunner.csproj
@@ -61,6 +61,15 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Outputs\FailedSpecificationsSummary.cs" />
+    <Compile Include="Outputs\SilentOutput.cs" />
+    <Compile Include="Outputs\VerboseOutput.cs" />
+    <Compile Include="Reporting\DefaultBufferedConsole.cs" />
+    <Compile Include="Reporting\IBuffer.cs" />
+    <Compile Include="Reporting\IConsole.cs" />
+    <Compile Include="Outputs\IOutput.cs" />
+    <Compile Include="Reporting\RunListener.cs" />
+    <Compile Include="Reporting\BufferedAssemblyRunReporter.cs" />
     <Compile Include="Utils\ExitCode.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />

--- a/ParallelMSpecRunner/Reporting/BufferedAssemblyRunReporter.cs
+++ b/ParallelMSpecRunner/Reporting/BufferedAssemblyRunReporter.cs
@@ -1,0 +1,103 @@
+using System;
+using Machine.Specifications.Reporting.Integration;
+using Machine.Specifications.Runner.Utility;
+using ParallelMSpecRunner.Outputs;
+using ParallelMSpecRunner.Utils;
+
+namespace ParallelMSpecRunner.Reporting
+{
+    /// <summary>
+    /// The idea here is that we buffer all output and then once we are done - 
+    /// we signal the owner.
+    /// </summary>
+    public class BufferedAssemblyRunReporter : ISpecificationRunListener, ISpecificationResultProvider, IBuffer
+    {
+        private readonly RunListener _reporter;
+        private readonly IBufferedConsole _console;
+        private readonly InvokeOnce<BufferedAssemblyRunReporter> _onFinished;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="onFinished">Gets invoked when the runner is done</param>
+        /// <param name="options">Parameters from command line</param>
+        public BufferedAssemblyRunReporter(Action<BufferedAssemblyRunReporter> onFinished, Options options)
+        {
+            _console = new DefaultBufferedConsole();
+            var output = DetermineOutput(options, _console);
+            _onFinished = new InvokeOnce<BufferedAssemblyRunReporter>(onFinished);
+            _reporter = new RunListener(_console, output, new TimingRunListener());
+        }
+
+        public string Buffer
+        {
+            get { return _console.GetBuffer(); }
+        }
+
+        private IOutput DetermineOutput(Options options, IBufferedConsole console)
+        {
+            if (options.Silent)
+            {
+                return new SilentOutput();
+            }
+
+            return new VerboseOutput(console);
+        }
+
+        #region ISpecificationRunListener, ISpecificationResultProvider
+
+        public bool FailureOccurred {
+            get { return _reporter.FailureOccurred; }
+        }
+
+        public void OnAssemblyStart(AssemblyInfo assembly)
+        {
+            _reporter.OnAssemblyStart(assembly);
+        }
+
+        public void OnAssemblyEnd(AssemblyInfo assembly)
+        {
+            _reporter.OnAssemblyEnd(assembly);
+        }
+
+        public void OnRunStart()
+        {
+        }
+
+        public void OnRunEnd()
+        {
+            _reporter.OnRunEnd();
+            _onFinished.Invoke(this);
+        }
+
+        public void OnContextStart(ContextInfo context)
+        {
+            _reporter.OnContextStart(context);
+        }
+
+        public void OnContextEnd(ContextInfo context)
+        {
+            _reporter.OnContextEnd(context);
+        }
+
+        public void OnSpecificationStart(SpecificationInfo specification)
+        {
+            _reporter.OnSpecificationStart(specification);
+        }
+
+
+        public void OnSpecificationEnd(SpecificationInfo specification, Result result)
+        {
+            _reporter.OnSpecificationEnd(specification, result);
+        }
+
+        public void OnFatalError(ExceptionResult exception)
+        {
+            _reporter.OnFatalError(exception);
+            _onFinished.Invoke(this);
+        }
+
+        #endregion
+
+    }
+}

--- a/ParallelMSpecRunner/Reporting/BufferedAssemblyTeamCityReporter.cs
+++ b/ParallelMSpecRunner/Reporting/BufferedAssemblyTeamCityReporter.cs
@@ -11,7 +11,7 @@ namespace ParallelMSpecRunner.Reporting
     /// The idea here is that we buffer all output and then once we are done - 
     /// we signal the owner.
     /// </summary>
-    public class BufferedAssemblyTeamCityReporter : ISpecificationRunListener, ISpecificationResultProvider
+    public class BufferedAssemblyTeamCityReporter : ISpecificationRunListener, ISpecificationResultProvider, IBuffer
     {
         private readonly TeamCityReporter _reporter;
         private readonly StringBuilder _buffer;

--- a/ParallelMSpecRunner/Reporting/DefaultBufferedConsole.cs
+++ b/ParallelMSpecRunner/Reporting/DefaultBufferedConsole.cs
@@ -1,0 +1,24 @@
+﻿using System.Text;
+
+namespace ParallelMSpecRunner.Reporting
+{
+    public class DefaultBufferedConsole : IBufferedConsole
+    {
+        private readonly StringBuilder _buffer = new StringBuilder();
+
+        public void Write(string line)
+        {
+            _buffer.Append(line);
+        }
+
+        public void WriteLine(string line)
+        {
+            _buffer.AppendLine(line);
+        }
+        
+        public string GetBuffer()
+        {
+            return _buffer.ToString();
+        }
+    }
+}

--- a/ParallelMSpecRunner/Reporting/IBuffer.cs
+++ b/ParallelMSpecRunner/Reporting/IBuffer.cs
@@ -1,0 +1,7 @@
+﻿namespace ParallelMSpecRunner.Reporting
+{
+    public interface IBuffer
+    {
+        string Buffer { get; }
+    }
+}

--- a/ParallelMSpecRunner/Reporting/IConsole.cs
+++ b/ParallelMSpecRunner/Reporting/IConsole.cs
@@ -1,0 +1,9 @@
+﻿namespace ParallelMSpecRunner.Reporting
+{
+    public interface IBufferedConsole
+    {
+        void Write(string line);
+        void WriteLine(string line);
+        string GetBuffer();
+    }
+}

--- a/ParallelMSpecRunner/Reporting/RunListener.cs
+++ b/ParallelMSpecRunner/Reporting/RunListener.cs
@@ -1,0 +1,149 @@
+using System;
+using Machine.Specifications.Reporting.Integration;
+using Machine.Specifications.Runner.Utility;
+using ParallelMSpecRunner.Outputs;
+
+namespace ParallelMSpecRunner.Reporting
+{
+    public class RunListener : ISpecificationRunListener, ISpecificationResultProvider
+    {
+        readonly IBufferedConsole _console;
+        readonly TimingRunListener _timer;
+        readonly IOutput _output;
+        int _contextCount;
+        int _specificationCount;
+        int _passedSpecificationCount;
+        int _failedSpecificationCount;
+        bool _failureOccurred;
+        int _ignoredSpecificationCount;
+        int _unimplementedSpecificationCount;
+        ContextInfo _currentContext;
+        AssemblyInfo _currentAssembly;
+        readonly FailedSpecificationsSummary _summary;
+
+        public RunListener(IBufferedConsole console, IOutput output, TimingRunListener timer)
+        {
+            _console = console;
+            _timer = timer;
+            _output = output;
+            _summary = new FailedSpecificationsSummary(new VerboseOutput(console), console);
+        }
+
+        public bool FailureOccurred
+        {
+            get { return _failureOccurred || _failedSpecificationCount > 0; }
+        }
+
+        public void OnAssemblyStart(AssemblyInfo assembly)
+        {
+	        _currentAssembly = assembly;
+            _output.AssemblyStart(assembly);
+        }
+
+        public void OnAssemblyEnd(AssemblyInfo assembly)
+        {
+            _output.AssemblyEnd(assembly);
+        }
+
+        public void OnRunStart()
+        {
+            _output.RunStart();
+
+            _contextCount = 0;
+            _specificationCount = 0;
+            _failedSpecificationCount = 0;
+            _unimplementedSpecificationCount = 0;
+            _ignoredSpecificationCount = 0;
+            _passedSpecificationCount = 0;
+        }
+
+        public void OnRunEnd()
+        {
+            if (_contextCount == 0) return;
+
+            _output.RunEnd();
+            if (_currentAssembly != null)
+            {
+                _console.WriteLine("Specifications in " + _currentAssembly.Name);
+            }
+
+            _summary.WriteSummary();
+	        
+            var line = String.Format("Contexts: {0}, Specifications: {1}, Time: {2:s\\.ff} seconds",
+                                     _contextCount,
+                                     _specificationCount,
+                                     FormattableTimeSpan(_timer.GetRunTime()));
+
+            if (_failedSpecificationCount > 0 || _unimplementedSpecificationCount > 0)
+            {
+                line += String.Format(Environment.NewLine + "  {0} passed, {1} failed", _passedSpecificationCount, _failedSpecificationCount);
+                if (_unimplementedSpecificationCount > 0)
+                {
+                    line += String.Format(", {0} not implemented", _unimplementedSpecificationCount);
+                }
+                if (_ignoredSpecificationCount > 0)
+                {
+                    line += String.Format(", {0} ignored", _ignoredSpecificationCount);
+                }
+            }
+
+            _console.WriteLine("");
+            _console.WriteLine(line);
+        }
+
+        public void OnContextStart(ContextInfo context)
+        {
+            _currentContext = context;
+            _output.ContextStart(context);
+        }
+
+        public void OnContextEnd(ContextInfo context)
+        {
+            _output.ContextEnd(context);
+            _contextCount += 1;
+        }
+
+        public void OnSpecificationStart(SpecificationInfo specification)
+        {
+            _output.SpecificationStart(specification);
+        }
+
+        public void OnSpecificationEnd(SpecificationInfo specification, Result result)
+        {
+            _specificationCount += 1;
+            switch (result.Status)
+            {
+                case Status.Passing:
+                    _passedSpecificationCount += 1;
+                    _output.Passing(specification);
+                    break;
+                case Status.NotImplemented:
+                    _unimplementedSpecificationCount += 1;
+                    _output.NotImplemented(specification);
+                    break;
+                case Status.Ignored:
+                    _ignoredSpecificationCount += 1;
+                    _output.Ignored(specification);
+                    break;
+                default:
+                    _failedSpecificationCount += 1;
+                    _summary.RecordFailure(_currentContext, specification, result);
+                    _output.Failed(specification, result);
+                    break;
+            }
+        }
+
+        public void OnFatalError(ExceptionResult exception)
+        {
+            _failureOccurred = true;
+            _console.WriteLine("");
+            _console.WriteLine("Fatal Error");
+            _console.WriteLine(exception.ToString());
+        }
+
+        static DateTime FormattableTimeSpan(long milliseconds)
+        {
+            return DateTime.MinValue + TimeSpan.FromMilliseconds(milliseconds);
+        }
+    }
+}


### PR DESCRIPTION
Added StandardOutput option (--standardoutput) to produce results in a way regular mspec console runner does with support for --silent option. --silent option will be used only when --standardoutput is used.
If --standardoutput is not specified, the default team city reporting will be used.
